### PR TITLE
remove kanboard.ocf.io ingress

### DIFF
--- a/kubernetes/kanboard.yml.erb
+++ b/kubernetes/kanboard.yml.erb
@@ -61,12 +61,6 @@ spec:
           - backend:
               serviceName: kanboard-service
               servicePort: 80
-    - host: kanboard.ocf.io
-      http:
-        paths:
-          - backend:
-              serviceName: kanboard-service
-              servicePort: 80
     - host: kanboard.dev-kubernetes.ocf.berkeley.edu
       http:
         paths:


### PR DESCRIPTION
This is automatically handled by haproxy in the kubernetes lb.
See ocf/puppet#540.