### PR TITLE
Use usernames instead of real names

### DIFF
--- a/config.php
+++ b/config.php
@@ -10,6 +10,7 @@ define('LDAP_AUTH', true);
 define('LDAP_SERVER', 'ldaps://ldap.ocf.berkeley.edu');
 define('LDAP_USER_FILTER', 'uid=%s');
 define('LDAP_USER_BASE_DN', 'ou=People,dc=OCF,dc=Berkeley,dc=EDU');
+define('LDAP_USER_ATTRIBUTE_FULLNAME', 'uid'
 
 define('LDAP_GROUP_PROVIDER', true);
 define('LDAP_GROUP_BASE_DN', 'ou=Group,dc=OCF,dc=Berkeley,dc=EDU');

--- a/config.php
+++ b/config.php
@@ -10,7 +10,7 @@ define('LDAP_AUTH', true);
 define('LDAP_SERVER', 'ldaps://ldap.ocf.berkeley.edu');
 define('LDAP_USER_FILTER', 'uid=%s');
 define('LDAP_USER_BASE_DN', 'ou=People,dc=OCF,dc=Berkeley,dc=EDU');
-define('LDAP_USER_ATTRIBUTE_FULLNAME', 'uid'
+define('LDAP_USER_ATTRIBUTE_FULLNAME', 'uid');
 
 define('LDAP_GROUP_PROVIDER', true);
 define('LDAP_GROUP_BASE_DN', 'ou=Group,dc=OCF,dc=Berkeley,dc=EDU');


### PR DESCRIPTION
Real names are shown everywhere in kanboard, but at the OCF we usually prefer using usernames. This should work to make the switch, though I haven't tested it.